### PR TITLE
Fix for Issue #3

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = (context) => {
 
     // Fuzzy-match the query.
     let results = context.matchutil.fuzzy(bookmarks, query, x => x.name)
-        .filter(x => x.score >= 5) // Remove low-scoring items.
+        .filter(x => x.score >= 0.1) // Remove low-scoring items.
         .slice(0, MAX_RESULTS) // Limit results.
         .map(x => {
       return {


### PR DESCRIPTION
Hi Varun Ramesh,

the score value for results from fuzzy search ranges from 0 to 1. So comparing with 5 won't give any results. Set the value to compare with to 0.1.

Maybe 0.1 is not the perfect value but worked for me very well. Maybe you could consider to provide this as a preference option so users can choose indiviually.

Please feel free to contact me should you have any further questions.

Kind regards,
Vincent
